### PR TITLE
Improve optimiser performance by ~6x

### DIFF
--- a/src/proof/bound_method.rs
+++ b/src/proof/bound_method.rs
@@ -7,14 +7,14 @@ use crate::ast::Ident;
 pub type FullProver<'a> = ScopedSimpleProver<'a, Prover<'a>>;
 
 pub struct Prover<'a> {
-    bounds: Vec<(Ident<'a>, Bound<'a>)>,
+    bounds: Vec<Vec<(Ident<'a>, Bound<'a>)>>,
     max_depth: usize,
 }
 
 impl<'a> SimpleProver<'a> for Prover<'a> {
     fn new(reqs: Vec<Requirement<'a>>) -> Prover<'a> {
         Prover {
-            bounds: reqs.iter().map(|req| req.bounds()).flatten().collect(),
+            bounds: reqs.iter().map(|req| req.simplify().bounds()).collect(),
             max_depth: 10,
         }
     }


### PR DESCRIPTION
This is achieved by keeping the information regarding which bounds
originates from the same requirements. Then, when we make a
substitution, we don't give the child any of the bounds from the same
requirement since substituting a bound from the same requirement is
effectively just a change in variables that would have been achieved by
using that substitution in the first place.
This decreases the width of the optimisers trees significantly.

I am tentative to merge since I'm not yet 100% convinced that it doesn't effect the results at all. It passes all current tests but we should write more before merging.